### PR TITLE
Add services page with training catalog and success stories

### DIFF
--- a/index.html.rtf
+++ b/index.html.rtf
@@ -20,6 +20,7 @@
         <div class="popup-box">\
             <h2>Lose <span>10 pounds</span> in <span>5 weeks</span>... for <span>FREE!</span></h2>\
             <p>Fill in your contact information to receive your free eBook.</p>\
+            <p><a href="services.html">Our Training Services</a></p>\
         </div>\
 \
         <!-- Box 2: Input Fields -->\

--- a/services.html
+++ b/services.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Training Services</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Training Services</h1>
+    </header>
+    <main>
+        <section>
+            <h2>Service Catalog</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th scope="col">Service</th>
+                        <th scope="col">Description</th>
+                        <th scope="col">Duration</th>
+                        <th scope="col">Cost</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <th scope="row">Personal Training</th>
+                        <td>One-on-one coaching tailored to your goals.</td>
+                        <td>60-minute session</td>
+                        <td>$60 per session</td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Group Fitness</th>
+                        <td>High-energy workouts in a supportive group setting.</td>
+                        <td>45-minute session</td>
+                        <td>$20 per session</td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Nutrition Coaching</th>
+                        <td>Custom meal planning to complement your training.</td>
+                        <td>4-week program</td>
+                        <td>$150</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+        <section>
+            <h2>Client Success Stories</h2>
+            <article>
+                <h3>Jordan's Transformation</h3>
+                <figure>
+                    <img src="https://via.placeholder.com/300x200?text=Before" alt="Before photo of Jordan prior to training">
+                    <img src="https://via.placeholder.com/300x200?text=After" alt="After photo of Jordan showing improved fitness">
+                    <figcaption>Jordan lost 10 pounds and gained confidence through our personal training program.</figcaption>
+                </figure>
+            </article>
+            <article>
+                <h3>Riley's Strength Journey</h3>
+                <figure>
+                    <img src="https://via.placeholder.com/300x200?text=Before" alt="Before photo of Riley with limited strength">
+                    <img src="https://via.placeholder.com/300x200?text=After" alt="After photo of Riley lifting heavier weights">
+                    <figcaption>Riley increased overall strength and energy after joining our group fitness sessions.</figcaption>
+                </figure>
+            </article>
+        </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link main page to new Services page
- add Services page cataloging training offerings with descriptions, durations, and costs
- highlight client success stories with before/after images and descriptive alt text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68989531e1a0832e8afe62758d6c37a1